### PR TITLE
part 37,38 보충

### DIFF
--- a/SampleWeb/src/main/java/com/example/demo/constant/UrlConst.java
+++ b/SampleWeb/src/main/java/com/example/demo/constant/UrlConst.java
@@ -14,7 +14,7 @@ public class UrlConst {
 	// 유저관리페이지 (관리자전용)
 	public static final String USER_LIST = "/userList";
 	// 인증이 필요없는 페이지
-	public static final String[] NO_AUTHENTICATION = {LOGIN, SIGNUP, "/webjars/**"};
+	public static final String[] NO_AUTHENTICATION = {LOGIN, SIGNUP, "/webjars/**", "/css/**"};
 	
 	
 	


### PR DESCRIPTION
1. UrlConst클래스의 NO_AUTHENTICATION에 /css/**를 추가하여 css파일을 인증불필요 설정 => 처음 로그인을 했을 때 에러화면이 뜨는 이슈해결